### PR TITLE
llamafile : improve moe prompt eval speed on cpu

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -78,7 +78,7 @@ using json = nlohmann::ordered_json;
 //
 
 int32_t cpu_get_num_physical_cores() {
-#ifdef __linux__
+#if defined(__linux__) || defined(__COSMOPOLITAN__)
     // enumerate the set of thread siblings, num entries is num cores
     std::unordered_set<std::string> siblings;
     for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
@@ -113,7 +113,7 @@ int32_t cpu_get_num_physical_cores() {
     return n_threads > 0 ? (n_threads <= 4 ? n_threads : n_threads / 2) : 4;
 }
 
-#if defined(__x86_64__) && defined(__linux__) && !defined(__ANDROID__)
+#if defined(__x86_64__) && (defined(__linux__) || defined(__COSMOPOLITAN__)) && !defined(__ANDROID__)
 #include <pthread.h>
 
 static void cpuid(unsigned leaf, unsigned subleaf,
@@ -167,7 +167,7 @@ static int cpu_count_math_cpus(int n_cpu) {
  * Returns number of CPUs on system that are useful for math.
  */
 int32_t cpu_get_num_math() {
-#if defined(__x86_64__) && defined(__linux__) && !defined(__ANDROID__)
+#if defined(__x86_64__) && (defined(__linux__) || defined(__COSMOPOLITAN__)) && !defined(__ANDROID__)
     int n_cpu = sysconf(_SC_NPROCESSORS_ONLN);
     if (n_cpu < 1) {
         return cpu_get_num_physical_cores();

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -650,6 +650,21 @@ extern "C" {
         enum ggml_cgraph_eval_order order;
     };
 
+    struct ggml_compute_state_shared;
+
+    struct ggml_compute_params {
+        // ith = thread index, nth = number of threads
+        int ith, nth;
+
+        // work buffer for all threads
+        size_t wsize;
+        void * wdata;
+
+        struct ggml_compute_state_shared * shared;
+    };
+
+    void ggml_barrier(struct ggml_compute_state_shared * shared);
+
     // scratch buffer
     struct ggml_scratch {
         size_t offs;

--- a/ggml/src/sgemm.h
+++ b/ggml/src/sgemm.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "ggml.h"
 #include <stdint.h>
 #include <stdbool.h>
 #ifdef __cplusplus
@@ -8,6 +9,13 @@ extern "C" {
 bool llamafile_sgemm(int64_t, int64_t, int64_t, const void *, int64_t,
                      const void *, int64_t, void *, int64_t, int, int,
                      int, int, int);
+
+bool llamafile_mixmul(const struct ggml_compute_params *, const struct ggml_tensor *,
+                      const struct ggml_tensor *, const struct ggml_tensor *, struct ggml_tensor *);
+
+size_t llamafile_mixmul_needs(const struct ggml_tensor *,
+                              const struct ggml_tensor *,
+                              const struct ggml_tensor *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This change introduces a llamafile_mixmul() API, that allows tinyBLAS to speed up "Mixture of Expert" models. On my Threadripper the Mixtral 8x7b F16 weights now process prompts 2x faster. I am also seeing a 60 percent improvement with Mixtral 8x22b Q4_0. Support is provided for Q8_0; it is also supported by tinyBLAS. MoE models spend the most time in MUL_MAT_ID rather than MUL_MAT, which is why llamafile_sgemm() was not able to help them before. The new code works by decomposing the mixmul operation into fast 2d llamafile_sgemm() calls. This also adds BF16 support to tinyBLAS